### PR TITLE
[Tree] Fix TreeContainer focus event

### DIFF
--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -661,8 +661,11 @@ const TreeContainer = ({
       onBlur={(): void => {
         !focusedTreeNode.id && setZeroTabIndexOnFirstFocusableTreeItemElement();
       }}
-      onFocus={(): void => {
-        !focusedTreeNode.id && setFocusedTreeNode(getTreeNodeWithId(root, 1));
+      onFocus={(e): void => {
+        (e.target?.parentElement as any)?.role === 'tree' &&
+          e.target ===
+            (e.target?.parentElement as HTMLOListElement)?.firstElementChild &&
+          setFocusedTreeNode(getTreeNodeWithId(root, 1));
       }}
       onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
         [


### PR DESCRIPTION
Removes unnecessary initial focusing of the first tree item upon clicking another item. Evaluates if the parent of the focused element has the 'tree' role and if the focused element is its first child element. The `setFocusedTreeNode(getTreeNodeWithId(root, 1));` method only needs to run here to focus the first item when the `TreeContainer` component receives focus using navigation, the first element has the zero tab index, and that item has not received focus yet.